### PR TITLE
(fix) do not display multiple worlds

### DIFF
--- a/script_src/MapPointGuessHandler.js
+++ b/script_src/MapPointGuessHandler.js
@@ -54,7 +54,9 @@ export default class MapPointGuessHandler {
     L.tileLayer(tileUrl, {
       maxZoom: 18,
       attribution:
-        '© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> &amp; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+        '© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> &amp; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+      bounds: [[90, -180], [-90, 180]],
+      noWrap: true
     }).addTo(map);
 
     this.mapBounds = map.getBounds();

--- a/styles_src/mapPointGuess.scss
+++ b/styles_src/mapPointGuess.scss
@@ -73,6 +73,7 @@ $q-quiz-marker-label-height: 20px;
 }
 .leaflet-container {
   overflow: hidden;
+  background-color: transparent;
 }
 .leaflet-tile,
 .leaflet-marker-icon,


### PR DESCRIPTION
- This makes Leaflet not loading tiles for multiple worlds but just showing the transparent background if user zooms out too much as in https://github.com/nzzdev/Q-map/pull/53
- Fixes https://github.com/nzzdev/Q-quiz/issues/48
- Prettier formatting in separate commit