### PR TITLE
change font style for not moved number guess range input message

### DIFF
--- a/script_src/NumberGuessHandler.js
+++ b/script_src/NumberGuessHandler.js
@@ -84,8 +84,8 @@ export default class NumberGuessHandler {
     defaultInputValueMessageElement.classList.add(
       "q-quiz-invalid-input-message"
     );
-    defaultInputValueMessageElement.classList.add("s-font-text-s");
-    defaultInputValueMessageElement.classList.add("s-font-text-s--strong");
+    defaultInputValueMessageElement.classList.add("s-font-note");
+    defaultInputValueMessageElement.classList.add("s-font-note--strong");
     defaultInputValueMessageElement.innerHTML =
       "Sie haben den Schieberegeler nicht bewegt, trotzdem die Position speichern?";
     answerButton.parentNode.insertBefore(


### PR DESCRIPTION
- this changes the font style from `s-font-text-s s-font-text-s--strong` to `s-font-note s-font-note--strong` for the message displayed when submit is clicked without moving the range input for number guess questions
- this is done because of the upcoming change of `s-font-text-s--strong` in sophie-font (described in https://3.basecamp.com/3500782/buckets/1333489/todos/1352870478)
- designers decided about this change in the linked issue
- deployed on test

I'd appreciate If you could release this or next week.